### PR TITLE
🚸 Add fallback local fonts in font-family

### DIFF
--- a/src/assets/css/_global.scss
+++ b/src/assets/css/_global.scss
@@ -1,5 +1,13 @@
 html {
-  font-family: 'open-sans', 'source-han-sans-traditional', sans-serif;
+  font-family: 'open-sans',
+               'source-han-sans-traditional',
+               'Open Sans',
+               'Source Sans Pro',
+               'Noto Sans',
+               'Microsoft JhengHei',
+               'Microsoft YaHei',
+               'Arial',
+               sans-serif;
   font-size: 16px;
 }
 


### PR DESCRIPTION
make font flash less obvious, make missing simplified chinese font less obvious