### PR TITLE
🐛 Fix ContentCard not triggered in non-observer lazyload

### DIFF
--- a/src/components/ContentList.vue
+++ b/src/components/ContentList.vue
@@ -3,6 +3,7 @@
     <transition
       name="content-list-layout-"
       mode="in-out"
+      @after-leave="$Lazyload.lazyLoadHandler()"
     >
       <div
         :key="state"


### PR DESCRIPTION
guess: the transition `in-out` cause the old list shadowed the new list, thus not lazy load (default event mode) won't trigger
seems not to be a problem in modern browser which we use intersection observer
```
in-out: New element transitions in first, then when complete, the current element transitions out.
```