### PR TITLE
🐛 Try to mitigate error in ios

### DIFF
--- a/src/util/SwiperDirectives.js
+++ b/src/util/SwiperDirectives.js
@@ -56,7 +56,7 @@ const swiperDirective = globalOptions => {
     // Init
     bind(el, binding, vnode) {
       const self = vnode.context
-      if (el.className.indexOf('swiper-container') === -1) {
+      if (typeof el.className === 'string' && el.className.indexOf('swiper-container') === -1) {
         el.className += ((el.className ? ' ' : '') + 'swiper-container')
       }
     },


### PR DESCRIPTION
I am seeing some 
```
TypeError: a[b].target.className.indexOf is not a function. (In 'a[b].target.className.indexOf(bc)', 'a[b].target.className.indexOf' is undefined)
--
```
error from sentry, mainly from ios chrome
not sure if some swiper function would be broken by this PR though