### PR TITLE
🐛 Guard civic view change event when state didn't change

### DIFF
--- a/src/components/CivicSubscriptionView/CivicSubscriptionView.vue
+++ b/src/components/CivicSubscriptionView/CivicSubscriptionView.vue
@@ -520,6 +520,7 @@ export default {
         this.stateHistory = [];
       }
       const { state } = this;
+      if (newState === state) return;
       if (state !== 'loading') {
         this.stateHistory.push(state);
       }


### PR DESCRIPTION
To prevent duplicate state change events