### PR TITLE
🐛 Allow civic liker in past_due or grace period to enter civic setting page

### DIFF
--- a/src/components/CivicSettingsV1.vue
+++ b/src/components/CivicSettingsV1.vue
@@ -37,6 +37,10 @@
                 )
                   | {{ $t('SettingsCivicPage.editPaymentMethod') }}
               .settings-civic-page__billing-summary-row.liker-comparison-card__b--mx
+                v-if=isPastDueUser
+                .settings-civic-page__billing-summary-row-value.text-danger
+                  | {{ $t('SettingsCivicPage.paymentExpired') }}
+              .settings-civic-page__billing-summary-row.liker-comparison-card__b--mx
                 label.settings-civic-page__billing-summary-row-label
                   | {{ $t(`SettingsCivicPage.billingSummary.${getUserSubscriptionInfo.willCancel ? 'cancel' : 'nextBilling'}Date`) }}
                 .settings-civic-page__billing-summary-row-value
@@ -49,7 +53,7 @@
         )
           | {{ $t('SettingsCivicPage.resumeSubscription') }}
         NuxtLink.btn.btn--plain.btn--auto-size.text-12(
-          v-else-if="getUserShouldRenewCivic"
+          v-else-if="getUserShouldRenewCivic && !isPastDueUser"
           :to="{ name: 'civic-register-stripe', query: { civic_liker_version: '1', utm_source: 'settings-civic' } }"
         )
           | {{ $t('SettingsCivicPage.resumeSubscription') }}
@@ -73,12 +77,6 @@
               )
                 | {{ buttonText }}
         br
-        a.btn.btn--plain.btn--auto-size.text-12(
-          v-if="getUserShouldRenewCivic && isPastDueUser"
-          :href="getStripeBillingPortalAPI"
-        )
-        | {{ $t('SettingsCivicPage.editPaymentMethod') }}
-        | /
         NuxtLink.btn.btn--plain.btn--auto-size.text-12(
           v-if="getUserShouldRenewCivic && !isPastDueUser"
           :to="{ name: 'civic-register-stripe', query: { civic_liker_version: '1', utm_source: 'settings-civic' } }"
@@ -223,7 +221,7 @@ export default {
     ...mapActions(['fetchUserSubscriptionInfo', 'resumeCanceledSubscription']),
 
     async fetchSubscriptionInfo({ force = false } = {}) {
-      if (this.getUserIsCivicLikerPaid) {
+      if (this.getUserIsCivicLikerPaid || this.getUserShouldRenewCivic) {
         try {
           if (force || !this.getUserSubscriptionInfo) {
             await this.fetchUserSubscriptionInfo();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -422,6 +422,7 @@
       "cancelDate": "Will cancel at",
       "nextBillingDate": "Next billing date"
     },
+    "paymentExpired": "Payment failed for your recent subscription payment. Please update your billing method",
     "editPaymentMethod": "Edit",
     "resumeSubscription": "Resume Civic Liker subscription",
     "cancelSubscription": "Cancel Civic Liker subscription"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -441,6 +441,7 @@
       "cancelDate": "訂閱結束日期",
       "nextBillingDate": "下次付款日期"
     },
+    "paymentExpired": "最近一次訂閱付款失敗，請修改你的付款方法",
     "editPaymentMethod": "修改",
     "resumeSubscription": "延續《讚賞公民》訂閱",
     "cancelSubscription": "取消《讚賞公民》訂閱"

--- a/src/pages/settings/civic.vue
+++ b/src/pages/settings/civic.vue
@@ -24,7 +24,8 @@ export default {
     ...mapGetters(['getUserIsCivicLikerV2']),
   },
   fetch({ store, redirect }) {
-    if (!store.getters.getUserIsCivicLiker) {
+    const { getUserIsCivicLiker, getUserShouldRenewCivic } = store.getters;
+    if (!getUserIsCivicLiker && !getUserShouldRenewCivic) {
       redirect({ name: 'id-civic', params: { id: DEFAULT_CL_SUPPORTER } });
     }
   },

--- a/src/pages/settings/payment/stripe/billing.vue
+++ b/src/pages/settings/payment/stripe/billing.vue
@@ -1,0 +1,19 @@
+<template lang="pug">
+  div
+    Spinner.mx-auto.my-96
+</template>
+
+<script>
+import { getStripeBillingPortalAPI } from '~/util/api';
+
+import Spinner from '~/components/Spinner/Spinner';
+
+export default {
+  components: {
+    Spinner,
+  },
+  asyncData({ redirect }) {
+    redirect(getStripeBillingPortalAPI());
+  },
+};
+</script>

--- a/src/server/api/routes/civic/stripe.js
+++ b/src/server/api/routes/civic/stripe.js
@@ -186,7 +186,8 @@ router.get('/civic/payment/stripe/billing', async (req, res, next) => {
         return;
       }
     }
-    res.sendStatus(404);
+    // redirect to civic settings page if customer not exists
+    res.redirect(`${EXTERNAL_URL}/settings/civic`);
   } catch (err) {
     next(err);
   }

--- a/src/store/modules/getters/user.js
+++ b/src/store/modules/getters/user.js
@@ -7,6 +7,8 @@ export const getUserIsCivicLikerV2 = state =>
   state.user.civicLikerVersion === 2;
 export const getUserIsCivicLikerPaid = ({ user }) =>
   user.isSubscribedCivicLiker && !user.isCivicLikerTrial;
+export const getUserIsExpiredCivicLiker = ({ user }) =>
+  user.isExpiredCivicLiker;
 export const getUserShouldRenewCivic = ({ user }) =>
   user.isCivicLikerRenewalPeriod || user.isExpiredCivicLiker;
 export const getUserCivicLikerHalo = ({ user }) => {


### PR DESCRIPTION
- Add a page that directly links to stripe billing page so that we can set this url in url/customer support message
- Allow expired user to enter civic setting page (which default to show v1) so that that won't be in an infinite loop in civic pages
- Show a message if we detect the user is `past_due` instead of `cancel` or no subscription, so that billing method can be updated

Known issue:
- Would show v1 option page even for v2 user
- After updating billing method, invoice payment retry is not auto triggered. We still won't treat v2 user as v2 user, and they cannot enter v2 panel until a payment retry is triggered and success
<img width="595" alt="civic" src="https://user-images.githubusercontent.com/6198816/110914766-c4117480-8351-11eb-83ed-64019f63e398.png">
