### PR TITLE
🚨 Unify NFT background color type

### DIFF
--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -67,7 +67,8 @@ export default {
       return this.NFTClassMetadata.image;
     },
     NFTImageBackgroundColor() {
-      return this.NFTClassMetadata.background_color;
+      const color = this.NFTClassMetadata.background_color;
+      return typeof color === 'string' ? color : undefined;
     },
     NFTExternalUrl() {
       return this.NFTClassMetadata.external_url;


### PR DESCRIPTION
Need to investigate why `background_color` is not a string

[Example](https://api.like.co/likernft/metadata?class_id=likenft1f9dlnexdt6l4d8u2hh9ccm5g52q46sw2hllk4ntdhf7n6resg00s5hseuj)