### PR TITLE
⚡️ Lazy load iscn and wallet library

### DIFF
--- a/src/store/modules/actions/staticData.js
+++ b/src/store/modules/actions/staticData.js
@@ -1,10 +1,7 @@
 import * as TYPES from '@/store/mutation-types';
 import * as api from '@/util/api';
-import {
-  getClassInfo,
-  isValidHttpUrl,
-  formatOwnerInfoFromChain,
-} from '@/util/nft';
+import { isValidHttpUrl, formatOwnerInfoFromChain } from '@/util/nft';
+import { LIKECOIN_CHAIN_API } from '@/constant';
 
 const USER_INFO_EXPIRE_TIME = 1000 * 60 * 10; // 10 minutes
 
@@ -88,7 +85,10 @@ export async function lazyGetNFTPurchaseInfo({ getters, dispatch }, classId) {
 
 export async function fetchNFTMetadata({ commit }, classId) {
   let metadata;
-  const chainMetadata = await getClassInfo(classId);
+  // const chainMetadata = await getClassInfo(classId);
+  const { class: chainMetadata } = await this.$api.$get(
+    `${LIKECOIN_CHAIN_API}/cosmos/nft/v1beta1/classes/${classId}`
+  );
   const {
     name,
     description,

--- a/src/store/modules/actions/staticData.js
+++ b/src/store/modules/actions/staticData.js
@@ -85,6 +85,8 @@ export async function lazyGetNFTPurchaseInfo({ getters, dispatch }, classId) {
 
 export async function fetchNFTMetadata({ commit }, classId) {
   let metadata;
+  /* HACK: Use restful API instead of cosmjs to avoid loading libsodium,
+    which is huge and affects index page performance */
   // const chainMetadata = await getClassInfo(classId);
   const { class: chainMetadata } = await this.$api.$get(
     `${LIKECOIN_CHAIN_API}/cosmos/nft/v1beta1/classes/${classId}`

--- a/src/store/modules/actions/wallet.js
+++ b/src/store/modules/actions/wallet.js
@@ -1,10 +1,17 @@
-import { LikeCoinWalletConnector } from '@likecoin/wallet-connector';
-
 import { LIKECOIN_WALLET_CONNECTOR_CONFIG } from '@/constant/network';
 import * as types from '@/store/mutation-types';
 import { getAccountBalance } from '~/util/nft';
 import { getUserInfoMinByAddress } from '~/util/api';
 import { setLoggerUser } from '~/util/EventLogger';
+
+let likecoinWalletLib = null;
+
+export async function getLikeCoinWalletLib() {
+  if (!likecoinWalletLib) {
+    likecoinWalletLib = await import(/* webpackChunkName: "likecoin_wallet" */ '@likecoin/wallet-connector');
+  }
+  return likecoinWalletLib;
+}
 
 export function setKeplrInstallCTAPreset({ commit }, preset) {
   commit(types.WALLET_SET_KEPLR_INSTALL_CTA_PRESET, preset);
@@ -41,11 +48,12 @@ export async function initWallet(
   return true;
 }
 
-export function getConnector({ state, commit }) {
+export async function getConnector({ state, commit }) {
   if (state.connector) {
     return state.connector;
   }
-  const connector = new LikeCoinWalletConnector({
+  const lib = await getLikeCoinWalletLib();
+  const connector = new lib.LikeCoinWalletConnector({
     ...LIKECOIN_WALLET_CONNECTOR_CONFIG,
     keplrInstallCTAPreset: state.keplrInstallCTAPreset,
     cosmostationAppWC2Enabled: state.cosmostationAppWC2Enabled,

--- a/src/util/nft.js
+++ b/src/util/nft.js
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { BigNumber } from 'bignumber.js';
-import { ISCNQueryClient, ISCNSigningClient } from '@likecoin/iscn-js';
-import { parseNFTClassDataFields } from '@likecoin/iscn-js/dist/messages/parsing';
 import { PageRequest } from 'cosmjs-types/cosmos/base/query/v1beta1/pagination';
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 import {
@@ -11,9 +9,19 @@ import {
 } from '../constant';
 
 let queryClient = null;
+let iscnLib = null;
+
+export async function getISCNLib() {
+  if (!iscnLib) {
+    iscnLib = await import(/* webpackChunkName: "iscn_js" */ '@likecoin/iscn-js');
+  }
+  return iscnLib;
+}
+
 export async function getNFTQueryClient() {
   if (!queryClient) {
-    const client = new ISCNQueryClient();
+    const iscn = await getISCNLib();
+    const client = new iscn.ISCNQueryClient();
     await client.connect(LIKECOIN_CHAIN_NFT_RPC);
     queryClient = client;
   }
@@ -21,7 +29,8 @@ export async function getNFTQueryClient() {
 }
 
 export async function createNFTSigningClient(signer) {
-  const client = new ISCNSigningClient();
+  const iscn = await getISCNLib();
+  const client = new iscn.ISCNSigningClient();
   await client.connectWithSigner(LIKECOIN_CHAIN_NFT_RPC, signer);
   return client;
 }
@@ -30,7 +39,8 @@ export async function getClassInfo(classId) {
   const c = await getNFTQueryClient();
   const client = await c.getQueryClient();
   let { class: nftClass } = await client.nft.class(classId);
-  if (nftClass) nftClass = parseNFTClassDataFields(nftClass);
+  const iscn = await getISCNLib();
+  if (nftClass) nftClass = iscn.parseNFTClassDataFields(nftClass);
   return nftClass;
 }
 


### PR DESCRIPTION
The code split avoids loading @cosmjs thus the huge `libsodium` in front page for new users
Thus removing a few seconds js parsing block on main thread

Pre:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/6198816/193121868-28402b49-ca9c-437f-9d8f-c376d702783b.png">

Post:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/6198816/193121830-58303522-275b-4138-b2f8-5a365b16269e.png">
