### PR TITLE
Add back lazy load for campaign items

### DIFF
--- a/src/components/NFTCampaign/Item.vue
+++ b/src/components/NFTCampaign/Item.vue
@@ -1,34 +1,40 @@
 <template>
-  <NFTCampaignItemBase
-    :class-id="classId"
-    :title="NFTName"
-    :description="NFTDescription"
-    :url="NFTExternalUrl"
-    :img-src="NFTImageUrl"
-    :img-bg-color="NFTImageBackgroundColor"
-    :price="NFTPrice"
-    :owner-address="iscnOwner"
-    :owner-avatar-src="iscnOwnerAvatar"
-    :owner-count="ownerCount"
-    :owner-name="iscnOwnerDisplayName"
-    :own-count="ownCount"
-    :sold-count="collectedCount"
-    :is-loading="uiIsOpenCollectModal && isCollecting"
-    :view-details-label="$t('campaign_nft_item_view_details_label')"
-    :like-action-label="$t('campaign_nft_item_like_action_label')"
-    :sold-count-label="$t('campaign_nft_item_collected_count_label')"
-    :content-preview-props="{
-      to: {
-        name: 'nft-class-classId',
-        params: { classId: classId },
-      },
-      tag: 'NuxtLink',
-    }"
-    @view-details="handleClickViewDetails"
-    @view-content="handleClickViewContent"
-    @collect="handleClickCollect"
-    @like="handleLike"
-  />
+  <div class="relative">
+    <lazy-component
+      class="absolute inset-0 pointer-events-none"
+      @show="fetchInfo"
+    />
+    <NFTCampaignItemBase
+      :class-id="classId"
+      :title="NFTName"
+      :description="NFTDescription"
+      :url="NFTExternalUrl"
+      :img-src="NFTImageUrl"
+      :img-bg-color="NFTImageBackgroundColor"
+      :price="NFTPrice"
+      :owner-address="iscnOwner"
+      :owner-avatar-src="iscnOwnerAvatar"
+      :owner-count="ownerCount"
+      :owner-name="iscnOwnerDisplayName"
+      :own-count="ownCount"
+      :sold-count="collectedCount"
+      :is-loading="uiIsOpenCollectModal && isCollecting"
+      :view-details-label="$t('campaign_nft_item_view_details_label')"
+      :like-action-label="$t('campaign_nft_item_like_action_label')"
+      :sold-count-label="$t('campaign_nft_item_collected_count_label')"
+      :content-preview-props="{
+        to: {
+          name: 'nft-class-classId',
+          params: { classId: classId },
+        },
+        tag: 'NuxtLink',
+      }"
+      @view-details="handleClickViewDetails"
+      @view-content="handleClickViewContent"
+      @collect="handleClickCollect"
+      @like="handleLike"
+    />
+  </div>
 </template>
 
 <script>
@@ -52,12 +58,12 @@ export default {
       isCollecting: false,
     };
   },
-  mounted() {
-    this.updateNFTClassMetadata();
-    this.updateNFTPurchaseInfo();
-    this.updateNFTOwners();
-  },
   methods: {
+    fetchInfo() {
+      this.updateNFTClassMetadata();
+      this.updateNFTPurchaseInfo();
+      this.updateNFTOwners();
+    },
     async handleClickCollect() {
       logTrackerEvent(this, 'NFT', 'NFTCollect(Campaign)', this.classId, 1);
       if (!this.getAddress) {

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -70,6 +70,10 @@ export const LIKECOIN_NFT_API_WALLET = IS_TESTNET
 
 export const LIKECOIN_NFT_CAMPAIGN_ITEMS = IS_TESTNET
   ? [
+      'likenft1qehd8pcp33ds3myxpmpanag2aqz4ygzmrukgtn8a69qyhswa5uqs952yjn',
+      'likenft1xqnk77p73fg5yzvkdus089f2a5m0j0m2a7d9505zjp6p04y9sg9sp56c92',
+      'likenft1ma7zjcmw0wdyzcjv4gqc04ww2470xtdy6wsuj9nx3jxm9k50zznq0v23tr',
+      'likenft1p404aquvagp06aamry48kkzt6xhqkacupsdktdeallza2k4czp9q33v77r',
       'likenft10f06wfaql5fxf3g4sy8v57p98lzp7ad92cu34f9aeyhyeklchznsav5npg',
       'likenft1pwutfz4m6ez0qevzc3re9dsd4e7l4x39nsvud7kmrj5p70tg0nmqlz0wyk',
       'likenft1hajavhgv0zn7fe6j6f6ax82w9ry9jatv4q5jfudn0ws7hfylnv3qj8x70d',


### PR DESCRIPTION
Ref: https://github.com/hilongjw/vue-lazyload/blob/6c4c3e5108bf89b5c71842ab8fb191fd0f06aa4e/src/lazy-component.js#L12-L14
I couldn't reproduce the UI glitch but I think the reason is `<lazy-component/>` always renders an empty child at the beginning which gives zero height at the initial rendering, hence all items will be triggered `show` event

