### PR TITLE
🐛 Fix NFT cards overlapping

### DIFF
--- a/src/components/NFTPortfolio/Base.vue
+++ b/src/components/NFTPortfolio/Base.vue
@@ -44,10 +44,7 @@
           </div>
         </div>
         <Label preset="h5" class="mt-[12px] break-words" align="center">{{ title }}</Label>
-        <div
-          v-if="price !== undefined"
-          class="z-[500] flex justify-center mt-[16px]"
-        >
+        <div v-if="isWritingNft || (!isWritingNft && price !== undefined)" class="z-[500] flex justify-center mt-[16px]">
           <ProgressIndicator v-if="isCollecting" />
           <ButtonV2
             v-else
@@ -135,6 +132,10 @@ export default {
     ownCount: {
       type: Number,
       default: 0,
+    },
+    isWritingNft: {
+      type: Boolean,
+      default: true,
     },
   },
   methods: {

--- a/src/components/NFTPortfolio/Item.vue
+++ b/src/components/NFTPortfolio/Item.vue
@@ -8,6 +8,7 @@
       :class-id="classId"
       :title="NFTName"
       :price="NFTPrice"
+      :is-writing-nft="isWritingNFT"
       :collected-count="collectedCount"
       :collector-count="ownerCount"
       :user-display-name="iscnOwnerDisplayName"

--- a/src/pages/nft/class/_classId/index.vue
+++ b/src/pages/nft/class/_classId/index.vue
@@ -208,7 +208,6 @@ export default {
       toAddress: null,
       isLoading: true,
 
-      currentPrice: 0,
       isOpenTransferModal: false,
       errorMsg: '',
       isReadyToTransfer: false,


### PR DESCRIPTION
Because the price's API takes a longer time to respond, in the first render, the component does not count the height of the price button, which causes the problem of overlapping cards.

the first render:
<img width="1219" alt="截圖 2022-10-19 上午10 28 14" src="https://user-images.githubusercontent.com/75730405/196583055-078bb490-c00c-46bc-b3d0-9ab2cfa7d83e.png">

then get the price:
<img width="1209" alt="截圖 2022-10-19 上午10 28 24" src="https://user-images.githubusercontent.com/75730405/196583131-988b9597-3276-4dd1-8335-1a4c2980cbca.png">
