### PR TITLE
⚡️ Remove duplicated call to fetch NFT list

### DIFF
--- a/src/mixins/portfolio.js
+++ b/src/mixins/portfolio.js
@@ -204,15 +204,15 @@ export default {
     ...mapActions(['fetchNFTListByAddress']),
     async loadNFTListByAddress(address) {
       this.wallet = address;
+      const fetchPromise = this.fetchNFTListByAddress(address);
       if (!this.getNFTClassIdListByAddress(address)) {
         this.isLoading = true;
-        await this.fetchNFTListByAddress(address);
+        await fetchPromise;
         this.isLoading = false;
       }
       if (!this.sortedCreatedClassIds.length) {
         this.currentTab = 'collected';
       }
-      this.fetchNFTListByAddress(address);
     },
     goCollected() {
       this.currentTab = 'collected';


### PR DESCRIPTION
I am not sure if the extra call without await in the end is intentional though, seems most cases we call this on `mount` in other page
(But even if it's intentional it should not be written in this way)