### PR TITLE
⚡️ Use resized avatar url

### DIFF
--- a/src/components/Identity/Identity.avatar.vue
+++ b/src/components/Identity/Identity.avatar.vue
@@ -77,7 +77,10 @@ export default {
       ];
     },
     imageSrc() {
-      return this.url || DEFAULT_AVATAR;
+      return (this.url || DEFAULT_AVATAR).replace(
+        /size=\d+/,
+        `size=${this.size}`
+      );
     },
     imageStyle() {
       const borderWidth = `${this.size * 0.05}px`;


### PR DESCRIPTION
Now [user api](https://api.like.co/users/id/ckxpress/min) would return avatar in format like `https://api.like.co/users/id/ckxpress/avatar?size=400`, where we can define `size`
We can use properly sized image for display by replacing querystring