### PR TITLE
🐛 Fix nft chain metadata was not properly parsed

### DIFF
--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -111,7 +111,9 @@ export default {
       return this.NFTClassMetadata.iscn_id;
     },
     iscnOwner() {
-      return this.NFTClassMetadata.iscn_owner;
+      return (
+        this.NFTClassMetadata.iscn_owner || this.NFTClassMetadata.account_owner
+      );
     },
     iscnOwnerAvatar() {
       return this.iscnOwnerInfo.avatar || getIdenticonAvatar(this.iscnOwner);
@@ -287,9 +289,7 @@ export default {
     },
     async updateNFTClassMetadata() {
       await this.fetchNFTMetadata(this.classId);
-      this.updateDisplayNameList(
-        this.getNFTClassMetadataById(this.classId)?.iscn_owner
-      );
+      this.updateDisplayNameList(this.iscnOwner);
     },
     async updateNFTPurchaseInfo() {
       await this.fetchNFTPurchaseInfo(this.classId);

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -132,6 +132,10 @@ export default {
       return this.NFTClassMetadata.description;
     },
     NFTImageUrl() {
+      const { image = '' } = this.NFTClassMetadata;
+      const [schema, path] = image.split('://');
+      if (schema === 'ar') return `${ARWEAVE_ENDPOINT}/${path}`;
+      if (schema === 'ipfs') return `${IPFS_VIEW_GATEWAY_URL}/${path}`;
       return this.NFTClassMetadata.image;
     },
     NFTImageBackgroundColor() {

--- a/src/store/modules/nft.js
+++ b/src/store/modules/nft.js
@@ -172,7 +172,7 @@ const actions = {
     metadata = {
       name,
       description,
-      metadata: classMetadata,
+      ...classMetadata,
       parent,
       iscn_id: iscnId,
     };
@@ -182,19 +182,27 @@ const actions = {
         // eslint-disable-next-line no-console
         .catch(err => console.error(err));
       if (apiMetadata) metadata = { ...metadata, ...apiMetadata };
-    } else if (iscnId) {
-      const iscnRecord = await this.$api
-        .$get(api.getISCNRecord(iscnId))
-        // eslint-disable-next-line no-console
-        .catch(err => console.error(err));
-      const iscnOwner = iscnRecord?.owner;
-      const iscnRecordTimestamp = iscnRecord?.records?.[0]?.recordTimestamp;
-      if (iscnOwner)
+    }
+    if (!(metadata.iscn_owner || metadata.account_owner)) {
+      if (iscnId) {
+        const iscnRecord = await this.$api
+          .$get(api.getISCNRecord(iscnId))
+          // eslint-disable-next-line no-console
+          .catch(err => console.error(err));
+        const iscnOwner = iscnRecord?.owner;
+        const iscnRecordTimestamp = iscnRecord?.records?.[0]?.recordTimestamp;
+        if (iscnOwner)
+          metadata = {
+            ...metadata,
+            iscn_owner: iscnOwner,
+            iscn_record_timestamp: iscnRecordTimestamp,
+          };
+      } else if (parent.account) {
         metadata = {
           ...metadata,
-          iscn_owner: iscnOwner,
-          iscn_record_timestamp: iscnRecordTimestamp,
+          account_owner: parent.account,
         };
+      }
     }
     if (metadata.iscn_record_timestamp)
       metadata.iscn_record_timestamp = Date.parse(


### PR DESCRIPTION
- metadata are stored as `metadata.metadata` instead of  spreading to `metadata`
- handle iscn_owner not exists when uri is defined
- handle account type nft
- display nft image with ar:// and ipfs://