### PR TITLE
🐛 Fix tx without receiver is filtered for pnft

### DIFF
--- a/src/util/api/index.js
+++ b/src/util/api/index.js
@@ -212,8 +212,8 @@ export const getNFTEvents = ({
   const qsPayload = {
     class_id: classId,
     action_type: actionType,
-    ignore_to_list: ignoreToList,
   };
+  if (ignoreToList) qsPayload.ignore_to_list = ignoreToList;
   if (key) qsPayload.key = key;
   if (limit) qsPayload.limit = limit;
   return `${LIKECOIN_CHAIN_API}/likechain/likenft/v1/event?${querystring.stringify(


### PR DESCRIPTION
setting `ignore_to_list=` makes mint_nft / create_class etc goes away unexpectedly
Example:
https://node.testnet.like.co/likechain/likenft/v1/event?class_id=likenft1h5rx36c4f9aex6zsjl9dftn8qmglnjvpq88jdj3e2lwdgzz9m4nql0xkc8&nft_id=nft-02e8dd6a-999d-48f8-8add-02da61f433a7&action_type=%2Fcosmos.nft.v1beta1.MsgSend&action_type=mint_nft&action_type=new_class&ignore_to_list=&limit=100

vs

https://node.testnet.like.co/likechain/likenft/v1/event?class_id=likenft1h5rx36c4f9aex6zsjl9dftn8qmglnjvpq88jdj3e2lwdgzz9m4nql0xkc8&nft_id=nft-02e8dd6a-999d-48f8-8add-02da61f433a7&action_type=%2Fcosmos.nft.v1beta1.MsgSend&action_type=mint_nft&action_type=new_class&limit=100