### PR TITLE
🐛 Fix duplicated key issue

### DIFF
--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -371,10 +371,10 @@ export default {
           const historyInDB = data.list;
           const eventMap = new Map();
           historyOnChain.forEach(e => {
-            eventMap.set(`${e.txHash}-${e.nftId}`, e);
+            eventMap.set(`${e.txHash}-${e.nftId}-${e.event}`, e);
           });
           historyInDB.forEach(e => {
-            const key = `${e.txHash}-${e.nftId}`;
+            const key = `${e.txHash}-${e.nftId}-${e.event}`;
             if (eventMap.has(key)) {
               eventMap.get(key).price = e.price;
             }

--- a/src/pages/nft/class/_classId/_nftId.vue
+++ b/src/pages/nft/class/_classId/_nftId.vue
@@ -102,7 +102,7 @@
             <ul class="flex flex-col gap-[24px] w-full laptop:px-[24px]">
               <NFTMessage
                 v-for="m in messageList"
-                :key="m.txHash"
+                :key="`${m.txHash}-${m.event}`"
                 :type="m.event"
                 :tx-hash="m.txHash"
                 :from-type="m.fromType"


### PR DESCRIPTION
Since we may have `mint_nft` and `new_class` events in the same Tx.
The key should be multiple fields.