### PR TITLE
🩹 [Portfolio] Hide empty text in creator follow form

### DIFF
--- a/src/pages/_id/index.vue
+++ b/src/pages/_id/index.vue
@@ -59,7 +59,7 @@
           class="w-full"
           :creator-wallet-address="wallet"
           :creator-display-name="userDisplayName"
-          :is-empty="!nftClassListOfCreatedInOrder.length"
+          :is-empty="false"
         />
       </div>
 


### PR DESCRIPTION
As the form now appears on all tabs, it is weird to show hint for no created NFT if the tab has nothing

E.g. Have  collected NFT but no created NFT
### Before
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/17264716/207569719-a649ab9e-2577-4e27-9d81-b231e307c6f5.png">
### After
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/17264716/207570027-ec2653ba-b0c1-4c55-9846-b7230c56f0c4.png">