### PR TITLE
⚡️ Prevent layout shifting after loading in civic dashboard

### DIFF
--- a/src/components/CivicLikerV3/Dashboard.vue
+++ b/src/components/CivicLikerV3/Dashboard.vue
@@ -1,27 +1,29 @@
 <template>
-  <Transition name="fade" mode="out-in">
-    <div
-      v-if="!validatorAddress"
-      key="loading"
-      class="flex items-center justify-center min-h-[180px]"
-    >
-      <Spinner class="mx-auto" />
-    </div>
-    <CivicLikerV3PureDashboard
-      v-else
-      key="dashboard"
-      :status="status"
-      :is-signed-in="!!getAddress"
-      :avatar-src="walletUserAvatar"
-      :staking-validator-name="validatorName"
-      :staking-management-url="stakingManagementURL"
-      :staking-amount="stakingAmount"
-      :staking-amount-target="stakingAmountTarget"
-      :active-since="activeSince"
-      @register="handleRegister"
-      @sign-in="handleSignIn"
-    />
-  </Transition>
+  <div class="min-h-[720px]">
+    <Transition name="fade" mode="out-in">
+      <div
+        v-if="!validatorAddress"
+        key="loading"
+        class="flex items-center justify-center min-h-[180px]"
+      >
+        <Spinner class="mx-auto" />
+      </div>
+      <CivicLikerV3PureDashboard
+        v-else
+        key="dashboard"
+        :status="status"
+        :is-signed-in="!!getAddress"
+        :avatar-src="walletUserAvatar"
+        :staking-validator-name="validatorName"
+        :staking-management-url="stakingManagementURL"
+        :staking-amount="stakingAmount"
+        :staking-amount-target="stakingAmountTarget"
+        :active-since="activeSince"
+        @register="handleRegister"
+        @sign-in="handleSignIn"
+      />
+    </Transition>
+  </div>
 </template>
 
 <script>

--- a/src/components/CivicLikerV3/Page.vue
+++ b/src/components/CivicLikerV3/Page.vue
@@ -6,7 +6,7 @@
           <img
             src="~/assets/images/civic-liker-icon.png"
             :alt="$t('civic_page_v3_title')"
-            style="width:68px"
+            style="height:64px; width:68px"
           >
           <span class="ml-16 text-like-green text-24">{{
             $t('civic_page_v3_title')


### PR DESCRIPTION
Before:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/6198816/207912436-efab81a4-a8e2-411f-864d-61856777d903.png">

After:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/6198816/207912474-96955606-9081-4310-9141-e1405a0d6e19.png">
