### PR TITLE
🔍️ Use v-show instead of v-if for FAQ

### DIFF
--- a/src/components/NFTAboutPage/FAQItem.vue
+++ b/src/components/NFTAboutPage/FAQItem.vue
@@ -47,7 +47,7 @@
     </div>
 
     <Transition @enter="onEnter" @leave="onLeave">
-      <div v-if="isOpen">
+      <div v-show="isOpen">
         <div class="laptop:pl-[108px] px-[32px] pb-[24px]">
           <hr class="w-[32px] mb-[8px] border-[#EBEBEB]">
           <slot name="answer" />


### PR DESCRIPTION
Using `v-if` hides the answer from HTML unless clicked on, which makes it uncrawlable
Using `v-show` allows the content to still exists in HTML while having same UX