### PR TITLE
🐛 Fix NFT about page CTA is blocked

### DIFF
--- a/src/components/NFTAboutPage/index.vue
+++ b/src/components/NFTAboutPage/index.vue
@@ -11,7 +11,7 @@
       "
     >
       <section class="relative py-[32px] px-[24px]">
-        <NFTCampaignHero class="absolute inset-0" />
+        <NFTCampaignHero class="absolute inset-0 pointer-events-none" />
         <div class="relative mx-auto">
           <h1
             class="


### PR DESCRIPTION
<img width="958" alt="image" src="https://user-images.githubusercontent.com/6198816/218559454-2444f4d0-6865-445e-9be7-235bb71b48a4.png">

The svg animation is larger in zh version, which blocks the whole CTA button
It's still partly blocked in this PR, not sure how to style it better

Related: https://github.com/likecoin/liker-land/issues/932