### PR TITLE
🐛 Fix undefined type

### DIFF
--- a/src/pages/_id/index.vue
+++ b/src/pages/_id/index.vue
@@ -261,19 +261,21 @@ export default {
   },
   methods: {
     handleTopUserHover(i) {
+      const type = this.isCurrentTabCollected ? 'creator' : 'collector';
       logTrackerEvent(
         this,
         'portfolio',
-        `portfolio_top_${this.type}_hover`,
+        `portfolio_top_${type}_hover`,
         `${i}`,
         1
       );
     },
     handleTopUserClick(i) {
+      const type = this.isCurrentTabCollected ? 'creator' : 'collector';
       logTrackerEvent(
         this,
         'portfolio',
-        `portfolio_top_${this.type}_click`,
+        `portfolio_top_${type}_click`,
         `${i}`,
         1
       );


### PR DESCRIPTION
refactoring error, `this.type` does not exists in parent