### PR TITLE
👽 Fetch followee API bafore getEvents

### DIFF
--- a/src/pages/notifications/index.vue
+++ b/src/pages/notifications/index.vue
@@ -350,6 +350,7 @@ export default {
     ...mapActions(['fetchWalletEvents', 'updateEventLastSeenTs']),
     async handleRefresh() {
       this.updateEventLastSeenTs(this.lastUpdatedTime);
+      await this.walletFetchFollowees();
       await this.fetchWalletEvents();
     },
     handleClickEvent() {

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -446,7 +446,10 @@ const actions = {
         from: address,
       };
       await this.$api.post(postUserV2Login(), data);
-      await dispatch('walletFetchSessionUserInfo', address);
+      await Promise.all([
+        dispatch('walletFetchSessionUserInfo', address),
+        dispatch('walletFetchFollowees'),
+      ]);
     } catch (error) {
       commit(WALLET_SET_USER_INFO, null);
       if (error.message === 'Request rejected') {


### PR DESCRIPTION
- Fetch followee before displaying the notification count. (signLogin)
- Re-fetch the followee list to update the event sender. (handleRefresh)