### PR TITLE
🐛 Fix some signers not provide sign method

### DIFF
--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -499,7 +499,7 @@ const actions = {
       const {
         signed: message,
         signature: { signature, pub_key: publicKey },
-      } = await state.signer.sign(address, payload);
+      } = await (state.signer.sign || state.signer.signAmino)(address, payload);
       const data = {
         signature,
         publicKey: publicKey.value,


### PR DESCRIPTION
It appears that the inability of users to log in to liker.land using the Liker Land app is due to this reason.