### PR TITLE
🐛 Guard metadata fetched from URI

### DIFF
--- a/src/store/modules/nft.js
+++ b/src/store/modules/nft.js
@@ -374,7 +374,9 @@ const actions = {
           console.error(err);
         }
       });
-      if (apiMetadata) metadata = { ...metadata, ...apiMetadata };
+      if (apiMetadata && typeof apiMetadata === 'object') {
+        metadata = { ...metadata, ...apiMetadata };
+      }
     }
     if (!(metadata.iscn_owner || metadata.account_owner)) {
       const iscnId = parent?.iscn_id_prefix;
@@ -422,7 +424,9 @@ const actions = {
           console.error(err);
         }
       });
-      if (apiMetadata) metadata = { ...metadata, ...apiMetadata };
+      if (apiMetadata && typeof apiMetadata === 'object') {
+        metadata = { ...metadata, ...apiMetadata };
+      }
     }
     commit(TYPES.NFT_SET_NFT_METADATA, { classId, nftId, metadata });
     return metadata;


### PR DESCRIPTION
Found a case which the URI refers to a GIF file, then axios converted the data into a looooooong string (length = `9475978`), which is then assigned to `apiMetadata`, causing OOM in object spread operations and `Vue.set` (or further processing from other computed / watched logics, not sure)