### PR TITLE
🌐 Always redirect to browser local for no prefix path

### DIFF
--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -286,8 +286,8 @@ const nuxtConfig = {
     defaultLocale: 'zh-Hant',
     langDir: '~/locales/',
     detectBrowserLanguage: {
-      redirectOn: 'root',
-      alwaysRedirect: true
+      useCookie: false,
+      redirectOn: 'no prefix',
     },
   },
 


### PR DESCRIPTION
Desired behaviour:
- go to browser locale for any non-prefix path
- do not enable cookie since firebase function restriction
- use user selected locale (from api) if one is set