### PR TITLE
🚑️ Use ADR-036 for login signing for Cosmostation

### DIFF
--- a/src/server/api/routes/users/v2/auth.js
+++ b/src/server/api/routes/users/v2/auth.js
@@ -46,7 +46,13 @@ router.get('/self', authenticateV2Login, async (req, res, next) => {
 });
 
 router.post('/login', async (req, res, next) => {
-  const { from: inputWallet, signature, publicKey, message } = req.body;
+  const {
+    from: inputWallet,
+    signature,
+    publicKey,
+    message,
+    signMethod,
+  } = req.body;
   try {
     if (!inputWallet || !signature || !publicKey || !message) {
       res.sendStatus(400);
@@ -63,6 +69,7 @@ router.post('/login', async (req, res, next) => {
         publicKey,
         message,
         inputWallet,
+        signMethod,
       });
     } catch (err) {
       res.status(401).send(err.message);

--- a/src/util/cosmos.js
+++ b/src/util/cosmos.js
@@ -1,5 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bech32 from 'bech32';
+import stringify from 'fast-json-stable-stringify';
+
+import {
+  LOGIN_MESSAGE,
+  LIKECOIN_CHAIN_ID,
+  LIKECOIN_CHAIN_MIN_DENOM,
+} from '@/constant/index';
 
 const ALLOWED_ADDRESS_PREFIXES = ['like', 'cosmos'];
 
@@ -24,4 +31,91 @@ export function deriveAllPrefixedAddresses(address) {
   return ALLOWED_ADDRESS_PREFIXES.map(prefix =>
     convertAddressPrefix(address, prefix)
   );
+}
+
+async function signLoginMessageMemo(signer, address, payload) {
+  const signingPayload = {
+    chain_id: LIKECOIN_CHAIN_ID,
+    memo: payload,
+    msgs: [],
+    fee: {
+      gas: '0',
+      amount: [
+        {
+          denom: LIKECOIN_CHAIN_MIN_DENOM,
+          amount: '0',
+        },
+      ],
+    },
+    sequence: '0',
+    account_number: '0',
+  };
+  const { signed, signature } = await signer.signAmino(address, signingPayload);
+  return {
+    signed: stringify(signed),
+    signature,
+    signMethod: 'memo',
+  };
+}
+
+async function signLoginMessageADR036(_, address, message) {
+  const signature = await window.cosmostation.cosmos.request({
+    method: 'cos_signMessage',
+    params: {
+      chainName: 'likecoin', // TODO: remove hardcode
+      signer: address,
+      message,
+    },
+  });
+  const signDoc = {
+    msgs: [
+      {
+        type: 'sign/MsgSignData',
+        value: {
+          signer: address,
+          data: window.btoa(message),
+        },
+      },
+    ],
+    account_number: '0',
+    sequence: '0',
+    fee: {
+      gas: '0',
+      amount: [],
+    },
+    memo: '',
+    chain_id: '',
+  };
+  return {
+    signed: stringify(signDoc),
+    signature,
+    signMethod: 'ADR-036',
+  };
+}
+
+export async function signLoginMessage(signer, address, { methodType }) {
+  const payload = [
+    `${LOGIN_MESSAGE}:`,
+    JSON.stringify({
+      ts: Date.now(),
+      address,
+    }),
+  ].join(' ');
+  const sign =
+    methodType === 'cosmostation'
+      ? signLoginMessageADR036
+      : signLoginMessageMemo;
+  const {
+    signed: message,
+    signature: { signature, pub_key: publicKey },
+    signMethod,
+  } = await sign(signer, address, payload);
+  const data = {
+    signature,
+    publicKey: publicKey.value,
+    message,
+    from: address,
+    signMethod,
+  };
+  return data;
 }


### PR DESCRIPTION
This is a hotfix, regular fix ("the right way") needs support of `signArbitrary` from `@likecoin/wallet-connector`.

Tested for Keplr (memo) and Cosmostation (ADR-036), both on browser extensions.