### PR TITLE
⚡️ Lazy fetch details for recommendation list

### DIFF
--- a/src/components/NFTPage/Recommendation.vue
+++ b/src/components/NFTPage/Recommendation.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col gap-[8px] bg-like-green rounded-[24px] py-[32px] overflow-hidden">
-    <div class="flex items-center justify-between px-[32px]">
+  <div class="bg-like-green rounded-[24px] overflow-hidden">
+    <div class="flex items-center justify-between pt-[32px] px-[32px] pb-[12px]">
       <NFTMessageIdentity
         type="creator"
         class="flex-shrink-0"
@@ -15,11 +15,12 @@
         {{ isFollowed ? $t('unfollow') : $t('follow') }}
       </ButtonV2>
     </div>
-    <ul class="relative pl-[32px] py-[12px] flex justify-start items-start gap-[24px] w-full overflow-x-scroll overflow-y-auto scrollbar-custom">
+    <ul class="relative flex justify-start items-start gap-[24px] w-full p-[32px] pt-[12px] overflow-x-scroll overflow-y-auto scrollbar-custom">
       <li v-for="(nft, index) in recommendedList" :key="index" @click="handleItemClick">
         <NFTPortfolioItem
           :class-id="nft.classId"
           :portfolio-wallet="iscnOwner"
+          :should-fetch-when-visible="true"
         />
       </li>
     </ul>

--- a/src/components/NFTPortfolio/Item.vue
+++ b/src/components/NFTPortfolio/Item.vue
@@ -1,8 +1,15 @@
 <template>
   <NuxtLink
+    class="relative"
     :to="detailsPageRoute"
     @click.native="handleClickViewDetails"
   >
+    <client-only v-if="shouldFetchWhenVisible">
+      <lazy-component
+        class="absolute inset-0 pointer-events-none"
+        @show="fetchInfo"
+      />
+    </client-only>
     <NFTPortfolioBase
       class="w-[310px]"
       :title="NFTName"
@@ -56,6 +63,10 @@ export default {
       type: String,
       default: undefined,
     },
+    shouldFetchWhenVisible: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data() {
@@ -84,6 +95,11 @@ export default {
     },
   },
   methods: {
+    fetchInfo() {
+      this.updateNFTClassMetadata();
+      this.updateNFTPurchaseInfo();
+      this.updateNFTOwners();
+    },
     async handleClickCollect() {
       logTrackerEvent(this, 'NFT', 'NFTCollect(Portfolio)', this.classId, 1);
       try {

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -764,7 +764,7 @@ export default {
         this.uiSetTxError(error.response?.data || error.toString());
         this.uiSetTxStatus(TX_STATUS.FAILED);
       } finally {
-        this.fetchNFTListByAddress(this.getAddress);
+        this.fetchNFTListByAddress({ address: this.getAddress });
         this.updateNFTOwners();
         this.updateNFTPurchaseInfo();
         this.updateNFTHistory();
@@ -911,11 +911,22 @@ export default {
     async fetchRecommendInfo() {
       this.isRecommendationLoading = true;
       try {
-        await Promise.all([
-          this.fetchNFTListByAddress(this.iscnOwner),
-          this.fetchNFTListByAddress(this.getAddress),
+        const promises = [
+          this.fetchNFTListByAddress({
+            address: this.iscnOwner,
+            shouldFetchDetails: false,
+          }),
           this.fetchNFTDisplayStateListByAddress(this.iscnOwner),
-        ]);
+        ];
+        if (this.getAddress) {
+          promises.push(
+            this.fetchNFTListByAddress({
+              address: this.getAddress,
+              shouldFetchDetails: false,
+            })
+          );
+        }
+        await Promise.all(promises);
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error(error);

--- a/src/mixins/portfolio.js
+++ b/src/mixins/portfolio.js
@@ -519,7 +519,7 @@ export const createPortfolioMixin = ({
     },
     async loadNFTListByAddress(address) {
       const fetchPromise = Promise.all([
-        this.fetchNFTListByAddress(address),
+        this.fetchNFTListByAddress({ address }),
         this.fetchNFTDisplayStateListByAddress(address),
       ]);
       if (!this.getNFTListMapByAddress(address)) {


### PR DESCRIPTION
The current recommendation list requires fetching all NFT classes created or collected by the creator, which results in retrieving all corresponding details that lead to an excessive number of API calls. This is also the reason why the creator's information failed to be fetched sometimes.

The fix is to fetch only the necessary recommendation items when they become visible on the screen.
