### PR TITLE
🚸 Allow closing collect modal after grant tx is posted

### DIFF
--- a/src/components/TxModal.vue
+++ b/src/components/TxModal.vue
@@ -18,7 +18,7 @@
 
     <slot name="top" />
 
-    <template v-if="!isShowQuitConfirm || ['processing', 'completed'].includes(uiTxNFTStatus)">
+    <template v-if="!isShowQuitConfirm || ['processing', 'processing_non_blocking', 'completed'].includes(uiTxNFTStatus)">
       <!-- Title & Message -->
       <div
         v-if="formattedStatusTitle || formattedStatusText || $slots.title || $slots.message"
@@ -45,7 +45,7 @@
       <slot name="default" />
 
       <ProgressIndicator
-        v-if="['sign', 'processing'].includes(uiTxNFTStatus)"
+        v-if="['sign', 'processing', 'processing_non_blocking'].includes(uiTxNFTStatus)"
         class="mt-[32px] mx-auto"
       />
 
@@ -233,6 +233,7 @@ export default {
               return undefined;
           }
         case 'processing':
+        case 'processing_non_blocking':
           return (
             this.processingTitle || this.$t('tx_modal_status_processing_title')
           );
@@ -256,6 +257,7 @@ export default {
           return undefined;
 
         case 'processing':
+        case 'processing_non_blocking':
           return this.$t('tx_modal_status_processing_text');
 
         case 'completed':
@@ -294,6 +296,7 @@ export default {
           return this.$t('tx_modal_button_ok');
 
         case 'processing':
+        case 'processing_non_blocking':
         default:
           return undefined;
       }

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -156,6 +156,7 @@ export const LIKECOIN_NFT_HIDDEN_ITEMS = new Set(
 export const TX_STATUS = {
   SIGN: 'sign',
   PROCESSING: 'processing',
+  PROCESSING_NON_BLOCKING: 'processing_non_blocking',
   COMPLETED: 'completed',
   INSUFFICIENT: 'insufficient',
   FAILED: 'failed',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -303,6 +303,8 @@
   "nft_collect_modal_subtitle_select_collect_method": "Select a collect method",
   "nft_collect_modal_title_collect": "Collect NFT",
   "nft_collect_modal_title_collecting": "Collecting NFT",
+  "nft_collect_modal_alert_success": "{name} was collected successfully",
+  "nft_collect_modal_alert_fail": "Collect {name} fail: {error}",
   "nft_details_page_activity_list_event": "Event",
   "nft_details_page_activity_list_event_buy_nft": "Purchase",
   "nft_details_page_activity_list_event_collect": "Collect",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -293,6 +293,8 @@
   "nft_collect_modal_subtitle_select_collect_method": "請選擇收藏方法",
   "nft_collect_modal_title_collect": "收藏作品",
   "nft_collect_modal_title_collecting": "正在收藏作品",
+  "nft_collect_modal_alert_success": "{name} 已成功收藏",
+  "nft_collect_modal_alert_fail": "收藏 {name} 失敗： {error}",
   "nft_details_page_activity_list_event": "事件",
   "nft_details_page_activity_list_event_buy_nft": "購買",
   "nft_details_page_activity_list_event_collect": "收集",

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -37,6 +37,7 @@ import {
 import { formatNumberWithUnit, formatNumberWithLIKE } from '~/util/ui';
 
 import walletMixin from '~/mixins/wallet';
+import alertMixin from '~/mixins/alert';
 import { createUserInfoMixin } from '~/mixins/user-info';
 import { createNFTClassCollectionMixin } from '~/mixins/nft-class-collection';
 
@@ -55,6 +56,7 @@ const defaultThemeColor = ['#D1D1D1', '#FFC123', '#ECBDF3'];
 export default {
   mixins: [
     walletMixin,
+    alertMixin,
     creatorInfoMixin,
     nftClassCollectionMixin,
     CrispMixinFactory({ isBootAtMounted: true }),
@@ -814,6 +816,12 @@ export default {
           });
           if (this.uiTxTargetClassId === classId) {
             this.uiSetTxStatus(TX_STATUS.COMPLETED);
+          } else {
+            this.alertPromptSuccess(
+              this.$t('nft_collect_modal_alert_success', {
+                name: this.NFTName,
+              })
+            );
           }
           return result.data;
         }
@@ -823,9 +831,17 @@ export default {
           this.handleError(errorHandler);
           return undefined;
         }
-        this.uiSetTxError(error.response?.data || error.toString());
+        const errMsg = error.response?.data || error.toString();
+        this.uiSetTxError(errMsg);
         if (this.uiTxTargetClassId === classId) {
           this.uiSetTxStatus(TX_STATUS.FAILED);
+        } else {
+          this.alertPromptError(
+            this.$t('nft_collect_modal_alert_fail', {
+              name: this.NFTName,
+              error: errMsg,
+            })
+          );
         }
       } finally {
         this.fetchNFTListByAddress({ address: this.getAddress });

--- a/src/pages/nft/fiat/stripe.vue
+++ b/src/pages/nft/fiat/stripe.vue
@@ -22,7 +22,9 @@ export default {
   },
   computed: {
     isPolling() {
-      return ['new', 'processing'].includes(this.status);
+      return ['new', 'processing', 'processing_non_blocking'].includes(
+        this.status
+      );
     },
     isCompleted() {
       return ['pendingClaim', 'done'].includes(this.status);


### PR DESCRIPTION
Allow closing collect modal during processing to allow quicker purchase/ reduce blocking
Shows close button after grant tx is posted to prevent spend limit grant from overlapping

Update:
Add alert prompt for closed modal results

Known possible issue:
Keep collecting a same class ID might make collect modal act funny, since current active checking is `modal classId === collected classId`