### PR TITLE
💄 Do not hide placeholder if book nft img src not set

### DIFF
--- a/src/components/NFTBook/ItemCard.vue
+++ b/src/components/NFTBook/ItemCard.vue
@@ -93,7 +93,6 @@
         </client-only>
         <div class="flex flex-col items-center shrink-0">
           <NFTCover
-            v-if="NFTImageUrl"
             :class="[
               'mt-[-48px]',
               coverClasses,


### PR DESCRIPTION
NFTCover would fill the image with placeholder if src not set
Now the placeholder only appears after nft metadata is loaded