### PR TITLE
🐛 Fix cropped supply table in home page

### DIFF
--- a/src/components/NFTSupply/Table.vue
+++ b/src/components/NFTSupply/Table.vue
@@ -6,7 +6,7 @@
       'border-shade-gray',
       {
         'pointer-events-none': isDisabled,
-        'border-b-0': shouldHideLowerBound,
+        'border-b-0 laptop:border-b-0': shouldHideLowerBound,
       },
     ]"
   >
@@ -15,7 +15,7 @@
         'w-full',
         shouldCollapseInMobile ? 'laptop:-my-[21px]' : '-my-[21px]',
         {
-          'mb-[0]': shouldHideLowerBound
+          'mb-[0] laptop:mb-[0]': shouldHideLowerBound
         },
       ]"
     >


### PR DESCRIPTION
Before 
![image](https://github.com/likecoin/liker-land/assets/17264716/06bc2d1f-a0b5-4c63-b262-229ac4481a6e)
After
<img width="1003" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/f192e684-943a-47cf-b26a-5fb139403646">
