### PR TITLE
⚡️ Do not load notification details on login

### DIFF
--- a/src/pages/notifications/index.vue
+++ b/src/pages/notifications/index.vue
@@ -83,6 +83,12 @@
           @click.native="handleClickEvent"
           @click.native.stop
         >
+          <client-only>
+            <lazy-component
+              class="absolute inset-0 pointer-events-none -top-full"
+              @show.once="fetchInfo(event)"
+            />
+          </client-only>
           <div class="flex items-center justify-start gap-[24px] mr-[12px]">
             <!-- dot -->
             <div
@@ -349,11 +355,21 @@ export default {
   },
 
   methods: {
-    ...mapActions(['fetchWalletEvents', 'updateEventLastSeenTs']),
+    ...mapActions([
+      'lazyGetNFTClassMetadata',
+      'lazyGetUserInfoByAddress',
+      'fetchWalletEvents',
+      'updateEventLastSeenTs',
+    ]),
     async handleRefresh() {
       this.updateEventLastSeenTs(this.lastUpdatedTime);
       await this.walletFetchFollowees();
-      await this.fetchWalletEvents();
+      await this.fetchWalletEvents({ shouldFetchDetails: false });
+    },
+    fetchInfo(event) {
+      this.lazyGetNFTClassMetadata(event.class_id);
+      this.lazyGetUserInfoByAddress(event.receiver);
+      this.lazyGetUserInfoByAddress(event.sender);
     },
     handleClickEvent() {
       logTrackerEvent(

--- a/src/pages/notifications/index.vue
+++ b/src/pages/notifications/index.vue
@@ -61,6 +61,7 @@
           :key="[event.tx_hash, event.class_id, event.nft_id, event.eventType].join('-')"
           :to="localeLocation(event.targetRoute)"
           :class="[
+            'relative',
             'flex',
             'justify-between',
             'items-center',

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -404,7 +404,10 @@ const actions = {
     }
   },
 
-  async fetchWalletEvents({ state, commit, dispatch }) {
+  async fetchWalletEvents(
+    { state, commit, dispatch },
+    { shouldFetchDetails = true }
+  ) {
     const { address, followees } = state;
     if (!address) {
       return;
@@ -463,9 +466,11 @@ const actions = {
     for (const list of events) {
       addresses.push(list.sender, list.receiver);
     }
-    [...new Set(addresses)]
-      .filter(a => !!a)
-      .map(a => dispatch('lazyGetUserInfoByAddress', a));
+    if (shouldFetchDetails) {
+      [...new Set(addresses)]
+        .filter(a => !!a)
+        .map(a => dispatch('lazyGetUserInfoByAddress', a));
+    }
 
     const promises = events.map(e => {
       if (
@@ -509,7 +514,9 @@ const actions = {
         })
         .sort((a, b) => b.timestamp - a.timestamp)
     );
-    classIds.map(id => dispatch('lazyGetNFTClassMetadata', id));
+    if (shouldFetchDetails) {
+      classIds.map(id => dispatch('lazyGetNFTClassMetadata', id));
+    }
     commit(WALLET_SET_EVENT_FETCHING, false);
   },
 
@@ -558,7 +565,7 @@ const actions = {
     }
     promises.push(dispatch('walletFetchFollowees'));
     await Promise.all(promises);
-    await dispatch('fetchWalletEvents');
+    await dispatch('fetchWalletEvents', { shouldFetchDetails: false });
   },
   async signLogin({ state, commit, dispatch }) {
     // Do not trigger login if the window is not focused


### PR DESCRIPTION
Notifications events are loaded whenever user is logged in or load likerland with a session
Now this is causing huge performance issue for user with loads of notifcations since all NFT metadata are fetched whenever a likerland page is opened