### PR TITLE
🚑️ Fix missing owner info in class page

### DIFF
--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -175,7 +175,10 @@ export default {
     },
     iscnOwner() {
       return (
-        this.NFTClassMetadata?.iscn_owner || this.NFTClassMetadata.account_owner
+        // TODO: refactor iscn owner data location
+        this.iscnData?.owner ||
+        this.NFTClassMetadata?.iscn_owner ||
+        this.NFTClassMetadata.account_owner
       );
     },
     iscnURL() {


### PR DESCRIPTION
<img width="1258" alt="image" src="https://github.com/likecoin/liker-land/assets/6198816/567412d1-989a-48bc-82a5-c5040792943d">
https://liker.land/zh-Hant/nft/class/likenft1uvcrlem98cquja0lly8jdyum3cw7glyw2ujpzl4ap5u9ah9eapzq0vxhad
iscnOwner is undefined now somehow