### PR TITLE
[TAS-115]💄 Hide "View Content" button if external_link is empty

### DIFF
--- a/src/components/NFTViewOptionList.vue
+++ b/src/components/NFTViewOptionList.vue
@@ -16,22 +16,6 @@
         <IconLinkExternal />
       </template>
     </ButtonV2>
-    <ButtonV2
-      v-else
-      class="w-full"
-      preset="outline"
-      :text="$t('nft_details_page_section_metadata_iscn')"
-      :href="iscnUrl"
-      target="_blank"
-      @click="handleClickViewContent"
-    >
-      <template #prepend>
-        <IconISCN class="w-[20px] text-dark-gray" />
-      </template>
-      <template #append>
-        <IconLinkExternal />
-      </template>
-    </ButtonV2>
 
     <p
       v-if="contentUrls.length && !isContentViewable"

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -238,7 +238,10 @@ export default {
       return this.nftMetadata.external_url || this.NFTExternalUrl;
     },
     externalUrl() {
-      return this.iscnUrl || this.nftExternalURL;
+      // The link to the NFT Book info may come from the iscn.json.
+      return this.nftIsNFTBook
+        ? this.iscnUrl || this.nftExternalURL
+        : this.nftExternalURL;
     },
     iscnData() {
       const data = this.getISCNMetadataById(this.iscnId);

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -238,7 +238,7 @@ export default {
       return this.nftMetadata.external_url || this.NFTExternalUrl;
     },
     externalUrl() {
-      // The link to the NFT Book info may come from the iscn.json.
+      // Prioritize iscn url for nft book since book info might be in iscn
       return this.nftIsNFTBook
         ? this.iscnUrl || this.nftExternalURL
         : this.nftExternalURL;


### PR DESCRIPTION
Currently, if there is no `external_url`, it will display the `iscnURL`. However, the metadata section will also have an iscnUrl btn, so I think it would be more intuitive to hide the "View Content" btn directly if there is no `external_url`.

current situation:
![截圖 2023-08-02 下午7 25 52](https://github.com/likecoin/liker-land/assets/75730405/b341a92b-74c7-4212-8567-80f3c7ac00f4)
<img width="1102" alt="截圖 2023-08-02 下午7 10 57" src="https://github.com/likecoin/liker-land/assets/75730405/eebd0729-1d40-485a-98ea-e3badc13acfd">
