### PR TITLE
[TAS-329] 🚑 Fix qs not passed through redirect

### DIFF
--- a/src/pages/dashboard/index.vue
+++ b/src/pages/dashboard/index.vue
@@ -3,10 +3,13 @@
     <ProgressIndicator />
   </div>
 </template>
+
 <script>
 export default {
-  fetch({ redirect, localeLocation }) {
-    redirect(localeLocation({ name: 'feed', query: { view: 'town' } }));
+  fetch({ redirect, localeLocation, query }) {
+    redirect(
+      localeLocation({ name: 'feed', query: { ...query, view: 'town' } })
+    );
   },
 };
 </script>


### PR DESCRIPTION
Liker Land app use `in_app=1` qs for hiding header and footer