### PR TITLE
[TAS-359] 🚸 Show "open PDF/EPUB" if URL has file extension

### DIFF
--- a/src/components/NFTViewOptionList.vue
+++ b/src/components/NFTViewOptionList.vue
@@ -113,6 +113,7 @@ export default {
   },
   computed: {
     normalizedContentURLs() {
+      // NOTE: Assuming if only `url` is set, it must contain the actual content rather than the book info
       return this.contentUrls.length ? this.contentUrls : [this.url];
     },
     shouldShowViewContentButton() {

--- a/src/components/NFTViewOptionList.vue
+++ b/src/components/NFTViewOptionList.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ButtonV2
-      v-if="url"
+      v-if="url && shouldShowViewContentButton"
       class="w-full"
       preset="outline"
       :text="$t(isNftBook ? 'nft_details_page_button_view_nft_book' : 'nft_details_page_button_view')"
@@ -18,7 +18,7 @@
     </ButtonV2>
 
     <p
-      v-if="contentUrls.length && !isContentViewable"
+      v-if="normalizedContentURLs.length && !isContentViewable"
       class="text-[14px] text-medium-gray text-center mt-[16px]"
     >{{ $t(isNftBook ? 'nft_details_page_button_collect_to_view_nft_book' : 'nft_details_page_button_collect_to_view') }}</p>
 
@@ -44,7 +44,7 @@
           <MenuList>
             <ul>
               <li
-                v-for="contentUrl in contentUrls"
+                v-for="contentUrl in normalizedContentURLs"
                 :key="contentUrl"
               >
                 <ButtonV2
@@ -59,7 +59,7 @@
       </template>
       <template v-else>
         <ButtonV2
-          v-for="contentUrl in contentUrls"
+          v-for="contentUrl in normalizedContentURLs"
           :key="contentUrl"
           class="mt-[12px] w-full"
           preset="outline"
@@ -112,11 +112,19 @@ export default {
     },
   },
   computed: {
+    normalizedContentURLs() {
+      return this.contentUrls.length ? this.contentUrls : [this.url];
+    },
+    shouldShowViewContentButton() {
+      return !this.normalizedContentURLs.includes(this.url);
+    },
     hasDuplicatedContentTypes() {
       const set = new Set(
-        this.contentUrls.map(url => url === this.getContentUrlType(url))
+        this.normalizedContentURLs.map(
+          url => url === this.getContentUrlType(url)
+        )
       );
-      return set.size !== this.contentUrls.length;
+      return set.size !== this.normalizedContentURLs.length;
     },
   },
   methods: {


### PR DESCRIPTION
Before
PDF URL display as 書訊
<img width="460" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/74cda944-0d37-43f4-9c91-9806fea593ae">

After
Detected URL with `.pdf`, shows `Open PDF`
<img width="399" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/69b76462-e2b4-4b59-8142-6e4ef1e07e50">
<img width="435" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/58a09327-f652-4c65-ae9e-cba926ea1971">

