### PR TITLE
🩹 Fix extra line break in NFT Book description

### DIFF
--- a/src/components/NFTBook/ItemCard.vue
+++ b/src/components/NFTBook/ItemCard.vue
@@ -117,9 +117,13 @@
           :text="$t('campaign_nft_book_just_arrived')"
         />
         <Label preset="h4" :class="titleStyle" :text="NFTName" />
-        <p :class="['text-14', 'whitespace-pre-line', descriptionStyle]">
-          {{ NFTDescription }}
-        </p>
+        <p
+          :class="[
+            'text-14',
+            'whitespace-pre-line',
+            descriptionStyle
+          ]"
+        >{{ NFTDescription }}</p>
         <div class="flex">
           <client-only>
             <NuxtLink


### PR DESCRIPTION
Since we have `whitespace-pre-line`, the line breaks in code are actually rendered out