### PR TITLE
⚡️ Prevent multiple connect attempt to likerland inapp browser

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -92,13 +92,15 @@ import { EXTERNAL_HOST } from '~/constant';
 
 import alertMixin from '~/mixins/alert';
 import inAppMixin from '~/mixins/in-app';
+import walletLoginMixin from '~/mixins/wallet-login';
 import { logTrackerEvent } from '~/util/EventLogger';
 
 export default {
-  mixins: [alertMixin, inAppMixin],
+  mixins: [alertMixin, inAppMixin, walletLoginMixin],
   data() {
     return {
       hasAnyDialogOpened: false,
+      isWalletAutoLoggingIn: false,
     };
   },
   head() {
@@ -147,6 +149,27 @@ export default {
     },
     isHomePage() {
       return this.getRouteBaseName(this.$route) === 'index';
+    },
+  },
+  watch: {
+    isInInAppBrowser: {
+      immediate: true,
+      async handler(isInInAppBrowser) {
+        if (
+          process.server ||
+          !isInInAppBrowser ||
+          this.walletHasLoggedIn ||
+          this.isWalletAutoLoggingIn
+        ) {
+          return;
+        }
+        try {
+          this.isWalletAutoLoggingIn = true;
+          await this.connectWallet();
+        } finally {
+          this.isWalletAutoLoggingIn = false;
+        }
+      },
     },
   },
   methods: {

--- a/src/mixins/in-app.js
+++ b/src/mixins/in-app.js
@@ -2,25 +2,11 @@ import { mapActions, mapGetters } from 'vuex';
 
 import { checkIsLikeCoinAppInAppBrowser } from '~/util/client';
 
-import walletLoginMixin from '~/mixins/wallet-login';
-
 export default {
-  mixins: [walletLoginMixin],
   computed: {
     ...mapGetters(['walletHasLoggedIn']),
     isInInAppBrowser() {
       return checkIsLikeCoinAppInAppBrowser(this.$route);
-    },
-  },
-  watch: {
-    isInInAppBrowser: {
-      immediate: true,
-      async handler(isInInAppBrowser) {
-        if (process.server || !isInInAppBrowser || this.walletHasLoggedIn) {
-          return;
-        }
-        await this.connectWallet();
-      },
     },
   },
   methods: {

--- a/src/pages/store/index.vue
+++ b/src/pages/store/index.vue
@@ -53,7 +53,10 @@
 <script>
 import { LIKECOIN_NFT_BOOK_FEATURED_ITEMS, EXTERNAL_HOST } from '~/constant';
 
-import { checkIsLikeCoinAppInAppBrowser } from '~/util/client';
+import {
+  checkIsForcedInAppPage,
+  checkIsLikeCoinAppInAppBrowser,
+} from '~/util/client';
 import { logTrackerEvent } from '~/util/EventLogger';
 
 import inAppMixin from '~/mixins/in-app';
@@ -64,6 +67,11 @@ export default {
   name: 'WritingNFTPage',
   mixins: [inAppMixin, navigationListenerMixin, walletMixin],
   layout: 'default',
+  fetch({ route, redirect, localeLocation }) {
+    if (checkIsForcedInAppPage(route)) {
+      redirect(301, localeLocation({ name: 'store-articles' }));
+    }
+  },
   head() {
     const title = this.$t('store_index_page_title');
     const description = this.$t('store_books_page_description');

--- a/src/util/client.js
+++ b/src/util/client.js
@@ -13,6 +13,10 @@ export function checkIsLikeCoinApp() {
   return userAgent.includes('LikeCoinApp');
 }
 
+export function checkIsForcedInAppPage(route) {
+  return route?.query?.in_app !== undefined;
+}
+
 export function checkIsLikeCoinAppInAppBrowser(route) {
-  return route?.query?.in_app !== undefined || checkIsLikeCoinApp();
+  return checkIsForcedInAppPage(route) || checkIsLikeCoinApp();
 }


### PR DESCRIPTION
- Redirect `in_app` from `/store` to `/store/articles` in `fetch` to prevent triggering inapp mixin
- Only use `in_app` qs for likerland app detection in fetch to prevent SSR inconsistent
- Move inapp watchers to default layout so that we won't have 3 watcher triggering when 3 pages import inapp mixin