### PR TITLE
🐛 Fix incorrect chapter path

### DIFF
--- a/src/pages/reader/epub.vue
+++ b/src/pages/reader/epub.vue
@@ -96,6 +96,7 @@ export default {
   data() {
     return {
       toc: [],
+      dirPath: '',
       selectedChapter: '',
       book: null,
       rendition: null,
@@ -129,7 +130,10 @@ export default {
       });
       this.rendition.display();
       this.rendition.on('rendered', (cfiRange, contents) => {
-        this.selectedChapter = this.rendition.currentLocation().start.href;
+        const path = this.rendition.currentLocation().start.href;
+        const pathArr = path.split('/');
+        this.selectedChapter = pathArr.pop();
+        this.dirPath = pathArr.join('/');
         this.contents = contents;
       });
 
@@ -152,7 +156,10 @@ export default {
       document.addEventListener('keydown', keyListener, false);
     },
     onChangeChapter() {
-      this.rendition.display(this.selectedChapter);
+      const chapter = this.dirPath
+        ? `${this.dirPath}/${this.selectedChapter}`
+        : this.selectedChapter;
+      this.rendition.display(chapter);
     },
     onClickGoToPrevPage() {
       this.rendition.prev();


### PR DESCRIPTION
Note: The TOC list utilizes the HTML or XHTML filenames of chapters as its keys. 
However, to navigate to a specific chapter, the `rendition.display` function requires the full path of the file. 
It's important to acknowledge that the folder structure within a zipped EPUB may vary from one file to another. 
The file paths could differ when dealing with different EPUB files.