### PR TITLE
🚸 Do not reinit wallet in sign login

### DIFF
--- a/src/components/AuthRequiredView.vue
+++ b/src/components/AuthRequiredView.vue
@@ -46,9 +46,10 @@
 
 <script>
 import walletMixin from '~/mixins/wallet';
+import walletLoginMixin from '~/mixins/wallet-login';
 
 export default {
-  mixins: [walletMixin],
+  mixins: [walletMixin, walletLoginMixin],
   props: {
     loginLabel: {
       type: String,
@@ -70,7 +71,11 @@ export default {
   methods: {
     async onClickLogin() {
       this.$emit('click-login');
-      await this.connectWallet();
+      if (this.hasConnectedWallet) {
+        await this.initIfNecessary({ isLogin: true });
+      } else {
+        await this.connectWallet();
+      }
       this.$emit('login');
     },
   },

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -448,16 +448,15 @@ const actions = {
     }
   },
 
-  async initIfNecessary({ dispatch }) {
+  async initIfNecessary({ dispatch }, { isLogin = false } = {}) {
     const connector = await dispatch('getConnector');
     const connection = await connector.initIfNecessary();
     if (connection) {
-      const { accounts, offlineSigner, method } = connection;
-      await dispatch('initWallet', {
-        accounts,
-        offlineSigner,
-        method,
-      });
+      if (isLogin) {
+        await dispatch('initWalletAndLogin', connection);
+      } else {
+        await dispatch('initWallet', connection);
+      }
     }
   },
 


### PR DESCRIPTION
In auth view, reuse current wallet connect method instead of re-initing whole select connect method flow