### PR TITLE
[TAS-1231] 🐛 Fix item wrapping issue due to insufficient width

### DIFF
--- a/src/components/NFTPortfolio/MainView.vue
+++ b/src/components/NFTPortfolio/MainView.vue
@@ -130,7 +130,7 @@
       <ul
         ref="portfolioGrid"
         :class="[
-          'self-stretch -mx-[12px] desktop:w-[644px] transition-all relative',
+          'self-stretch -mx-[12px] desktop:w-[668px] transition-all relative',
           {
             'opacity-0 pointer-events-none': isLoadingPortfolioItems,
           },


### PR DESCRIPTION
I think this issue occurred because I reduced the width in the previous PR
[💄 Add recommendation section to the empty portfolio page](https://github.com/likecoin/liker-land/pull/1529/commits/1071487aba931900045f00679f7e4b45b1f8512e#diff-1ecbb852d58b0749ca3f53a4e6e3380fcc0100dfee87ecb64004d8213f786b3fR133)


fix now
![截圖 2024-02-06 下午3 22 51](https://github.com/likecoin/liker-land/assets/75730405/0617088b-2412-434b-a236-a2dd9756a61d)
