### PR TITLE
🐛 Do not use nft mixin in non nft class component

### DIFF
--- a/src/components/NFTPortfolio/MainView.vue
+++ b/src/components/NFTPortfolio/MainView.vue
@@ -222,7 +222,6 @@ import { NFT_CLASS_LIST_SORTING, NFT_TYPE_FILTER_OPTIONS } from '~/util/nft';
 import { ellipsis } from '~/util/ui';
 
 import { tabOptions } from '~/mixins/portfolio';
-import nftMixin from '~/mixins/nft';
 
 const portfolioGridDebounceArgs = [
   60,
@@ -240,7 +239,6 @@ const SELECTED_FILTER = {
 };
 
 export default {
-  mixins: [nftMixin],
   props: {
     isNarrow: {
       type: Boolean,
@@ -448,17 +446,12 @@ export default {
     $route() {
       this.$nextTick(this.setupPortfolioGrid);
     },
-    async portfolioItemsTrimmed(items, prevItems) {
+    portfolioItemsTrimmed(items, prevItems) {
       if (this.isLoadingPortfolioItems) return;
-
       if (items.length === prevItems.length && this.portfolioGridController) {
         this.$nextTick(this.updatePortfolioGrid);
       } else {
         this.$nextTick(this.setupPortfolioGrid);
-      }
-
-      if (!items.length) {
-        await this.fetchRecommendInfo();
       }
     },
     portfolioItemsSortingValue() {

--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -1390,6 +1390,7 @@ export default {
       return m.memo;
     },
     async fetchRecommendInfo() {
+      if (this.isRecommendationLoading) return;
       this.isRecommendationLoading = true;
       try {
         const promises = [


### PR DESCRIPTION
- `NFTPortfolio/MainView.vue` contains many nft class instead of 1 nft class, but nft mixin expect an nft class id as it's root of data source
- We can't call `fetchRecommendInfo` from here, `iscnOwner` is undefined
- Somehow `portfolioItemsTrimmed` is modified if we call `fetchRecommendInfo` under these condition causing `fetchRecommendInfo` goes into an infinite loop

For a very quick fix, we should just not call `fetchRecommendInfo` from here, and maybe figure out why `portfolioItemsTrimmed` is modified and call `this.fetchCollectedNFTClassesByAddress(this.getAddress)` in a later PR
