### PR TITLE
⚡️ Remove lazy in <img> for nft cover

### DIFF
--- a/src/components/NFTCover.vue
+++ b/src/components/NFTCover.vue
@@ -137,7 +137,6 @@ export default {
     },
     imgProps() {
       return {
-        loading: 'lazy',
         // NOTE: Mitigate image deform before Tailwind CSS is loaded
         style: 'object-fit: cover;',
         ...this.$attrs,


### PR DESCRIPTION
Often the whole NFT card component is lazyloaded, setting lazy in  just mess up the image src http request priority