### PR TITLE
[TAS-1551] 💩 Fix missing formattedNFTPriceInUSD in collection page

### DIFF
--- a/src/mixins/nft-collection.js
+++ b/src/mixins/nft-collection.js
@@ -116,6 +116,11 @@ export default {
         params: { collectionId: this.collectionId },
       });
     },
+    formattedNFTPriceInUSD() {
+      return this.collectionPrice !== undefined
+        ? formatNumberWithUSD(this.collectionPrice)
+        : '-';
+    },
   },
   methods: {
     ...mapActions([


### PR DESCRIPTION
`formattedNFTPriceInUSD()` is used in `_collectionId` page but is not defined in collection mixin