### PR TITLE
[TAS-1433] ⚡️ Add fallback fonts after removing fonts from Typekit

### DIFF
--- a/src/assets/css/_global.scss
+++ b/src/assets/css/_global.scss
@@ -1,17 +1,3 @@
-html {
-  font-family: 'open-sans',
-               'source-han-sans-traditional',
-               'source-han-sans-simplified-c',
-               'Open Sans',
-               'Source Sans Pro',
-               'Noto Sans',
-               'Microsoft JhengHei',
-               'Microsoft YaHei',
-               'Arial',
-               sans-serif;
-  font-size: 16px;
-}
-
 @font-face {
   font-family: 'emoji';
   src: local("Apple Color Emoji"),

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -40,6 +40,9 @@ const nuxtConfig = {
    ** Headers of the page
    */
   head: {
+    htmlAttrs: {
+      class: ['text-[16px]', 'font-sans'],
+    },
     titleTemplate: titleChunk =>
       titleChunk
         ? `${titleChunk} - ${process.env.SITE_NAME}`

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -159,14 +159,28 @@ module.exports = {
 
     fontFamily: {
       irohamaru: ['irohamaru', 'sans-serif'],
-      proxima: ['proxima-nova', 'sans-serif'],
+      proxima: [
+        'proxima-nova',
+        'Avant Grade',
+        'STHeiti',
+        'Microsoft JhengHei',
+        'sans-serif',
+      ],
       sans: [
         'source-han-sans-traditional',
         'source-han-sans-simplified-c',
         'open-sans',
+        'STHeiti',
+        'Microsoft JhengHei',
         'sans-serif',
       ],
-      serif: ['source-han-serif-tc', 'source-han-serif-sc', 'serif'],
+      serif: [
+        'source-han-serif-tc',
+        'source-han-serif-sc',
+        'STSong',
+        'Microsoft YaHei',
+        'serif',
+      ],
       mono: ['monospace'],
       emoji: ['emoji'],
     },


### PR DESCRIPTION
- Tailwind will apply `font-sans` style to `<html>`, so we don't need to specify `font-sans` class to `<html>`
- the stylesheet of Tailwind (Newer version) from `likecoin-wallet-connector` is overriding some font styles, but it doesn't matter for now

<img width="596" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/d1436dc5-13ba-46ea-9ab3-f5e749f23e6d">

---

I just keep Proxima Nova for English since Typekit doesn't allow zero font
<img width="1571" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/fa83f2f7-be7f-4edc-80cc-fbd036a3b3f3">

<img width="579" alt="image" src="https://github.com/likecoin/liker-land/assets/17264716/04de102e-8ea5-4f8e-9ff7-d52ac87fade9">
