### PR TITLE
[TAS-1790] 🐛 Fix hydration mismatch caused by html comment

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -384,7 +384,7 @@
         <div
           class="desktop:grid grid-cols-5 items-stretch gap-[20px] flex-grow"
         >
-          <div class="col-span-2">
+          <div v-if="stickyBookstoreItem" class="col-span-2">
             <NFTBookItemCardV2
               :class="[bookstoreSectionStickyClass, 'w-full']"
               class-cover-frame-aspect-ratio="min-h-[360px] desktop:min-h-[0] desktop:aspect-[4/5]"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -653,7 +653,6 @@
               >
                 {{ $t('index_faq_title') }}
 
-                <!-- Faq title decoration -->
                 <svg
                   class="absolute pointer-events-none top-[50%] translate-y-[-45%] translate-x-[-50%] left-full w-full"
                   viewBox="0 0 311 328"


### PR DESCRIPTION
A layout change from a hydration mismatch page would cause double mount event