### PR TITLE
💄 Fix loading indicator behind book bind

### DIFF
--- a/src/pages/reader/epub.vue
+++ b/src/pages/reader/epub.vue
@@ -225,7 +225,7 @@
 
     <div
       v-if="isLoading"
-      class="fixed inset-0 flex flex-col justify-center items-center gap-[16px] bg-white"
+      class="z-[10] fixed inset-0 flex flex-col justify-center items-center gap-[16px] bg-white"
     >
       <ProgressIndicator
         :type="progressIndicatorType"


### PR DESCRIPTION
Before
<img width="326" alt="image" src="https://github.com/user-attachments/assets/04924eec-b08a-4706-ae4c-fac16de8f596">
After
<img width="326" alt="image" src="https://github.com/user-attachments/assets/24ea8a26-24fe-4712-9195-b3d99792f0c2">
