### PR TITLE
[TAS-2131] 🐛 Fix view content dropdown option name

### DIFF
--- a/src/components/NFTViewOptionList.vue
+++ b/src/components/NFTViewOptionList.vue
@@ -85,7 +85,7 @@
                 class="w-full"
                 preset="plain"
                 :text="
-                  getDownloadFilenameFromURL(contentUrl) ||
+                  getFilenameFromURL(contentUrl) ||
                     getContentUrlButtonText(contentUrl)
                 "
                 :download="getDownloadFilenameFromURL(contentUrl)"


### PR DESCRIPTION
Before
<img width="329" alt="image" src="https://github.com/user-attachments/assets/c504e552-bb0f-4593-88b9-1cc160b4eea3">
After
<img width="329" alt="image" src="https://github.com/user-attachments/assets/1dcc7999-a468-4f0c-ae02-cc8ec223e762">
