### PR TITLE
[TAS-2134] 🐛 Fix email is empty in free purchase

### DIFF
--- a/src/pages/nft/claim/index.vue
+++ b/src/pages/nft/claim/index.vue
@@ -924,6 +924,7 @@ export default {
     async startFreePurchase() {
       try {
         this.isClaimLoading = true;
+        this.claimingFreeEmail = this.walletEmail;
         this.navigateToState(NFT_CLAIM_STATE.CLAIMING);
         if (!this.claimingFreeEmail && !this.claimingAddress) {
           this.alertPromptError(


### PR DESCRIPTION
In `data()`, `walletEmail` is `undefined`
https://github.com/likecoin/liker-land/blob/52a1737950ede7fd19de0ffe139e35f2002eadd4/src/pages/nft/claim/index.vue#L548-L559

<img width="738" alt="Screenshot 2024-08-30 at 15 55 25" src="https://github.com/user-attachments/assets/63e7b5e8-7430-4a0a-aaff-c69f0e99ef58">
