### PR TITLE
🚑️ Guard undefined classId in recommend list filter

### DIFF
--- a/src/components/NFTPage/Recommendation.vue
+++ b/src/components/NFTPage/Recommendation.vue
@@ -168,7 +168,8 @@ export default {
           : this.nftFeaturedWNFT;
         // TODO: remove filter after recommendation support collection
         sourceData = sourceData.filter(nft =>
-          nft.classId.startsWith('likenft1')
+          // TODO: find out and fix classId undefined reason
+          nft.classId?.startsWith('likenft1')
         );
         while (
           normalizedRecommendedList.length < displayItemCount &&


### PR DESCRIPTION
Not sure why `classId` can be undefined when it seems to be used everywhere in this function