### PR TITLE
[TAS-2413] 📈 Set product data for 1st edition in og meta for fb

### DIFF
--- a/src/mixins/nft.js
+++ b/src/mixins/nft.js
@@ -449,6 +449,18 @@ export default {
           })
         : [defaultEdition];
     },
+    nftEdition() {
+      let edition;
+      if (this.editionPriceIndex !== undefined) {
+        edition = this.nftEditions.find(
+          e => e.index === this.editionPriceIndex
+        );
+      }
+      if (!edition) {
+        edition = this.nftEditions.find(item => item.stock > 0);
+      }
+      return edition;
+    },
     editionPriceIndex() {
       if (this.priceIndex !== undefined) return Number(this.priceIndex);
       if (!this.nftIsNFTBook) return undefined;
@@ -486,15 +498,7 @@ export default {
       });
     },
     nftBookAvailablePriceLabel() {
-      let edition;
-      if (this.editionPriceIndex !== undefined) {
-        edition = this.nftEditions.find(
-          e => e.index === this.editionPriceIndex
-        );
-      }
-      if (!edition) {
-        edition = this.nftEditions.find(item => item.stock > 0);
-      }
+      const edition = this.nftEdition;
       const purchasePrice = edition?.priceLabel;
       return purchasePrice;
     },

--- a/src/pages/nft/class/_classId/_nftId.vue
+++ b/src/pages/nft/class/_classId/_nftId.vue
@@ -503,7 +503,6 @@ export default {
           description: this.NFTDescription,
           brand,
           sku: this.classId,
-          iscn: this.iscnId,
           isbn: this.iscnData?.contentMetadata?.isbn,
           datePublished: this.iscnData?.recordTimestamp,
           bookFormat: this.nftIsNFTBook
@@ -514,6 +513,13 @@ export default {
             ''
           ),
           subjectOf: threeDModel,
+          additionalProperty: [
+            {
+              '@type': 'PropertyValue',
+              propertyID: 'iscn',
+              value: this.iscnId,
+            },
+          ],
         },
       },
     ];

--- a/src/pages/nft/class/_classId/index.vue
+++ b/src/pages/nft/class/_classId/index.vue
@@ -773,6 +773,11 @@ export default {
             property: 'product:condition',
             content: 'new',
           },
+          {
+            hid: 'product:custom_label_0',
+            property: 'product:custom_label_0',
+            content: this.iscnOwner,
+          },
         ].forEach(m => meta.push(m));
         meta.find(m => m.hid === 'og:url').content = `${EXTERNAL_HOST}${
           this.$route.path
@@ -780,7 +785,7 @@ export default {
         if (e.name) {
           let titleWithEdition =
             this.NFTName || this.$t('nft_details_page_title');
-          if (e.name) titleWithEdition += ` - ${e.name}`;
+          titleWithEdition += ` - ${e.name}`;
           if (this.iscnWorkAuthor) {
             titleWithEdition += ` - ${this.iscnWorkAuthor}`;
           }
@@ -792,6 +797,20 @@ export default {
             hid: 'product:isbn',
             property: 'product:isbn',
             content: this.iscnData?.contentMetadata?.isbn,
+          });
+        }
+        if (this.iscnWorkAuthor) {
+          meta.push({
+            hid: 'product:custom_label_1',
+            property: 'product:custom_label_1',
+            content: this.iscnWorkAuthor,
+          });
+        }
+        if (this.iscnData?.contentMetadata?.inLanguage) {
+          meta.push({
+            hid: 'product:custom_label_2',
+            property: 'product:custom_label_2',
+            content: this.iscnData?.contentMetadata?.inLanguage,
           });
         }
       }

--- a/src/pages/nft/class/_classId/index.vue
+++ b/src/pages/nft/class/_classId/index.vue
@@ -533,6 +533,38 @@ export default {
         this.$i18n.locale !== 'en' ? 'default-zh.jpg' : 'default.jpg'
       }`;
     const schemas = [];
+    const meta = [
+      {
+        hid: 'og:title',
+        property: 'og:title',
+        content: title,
+      },
+      {
+        hid: 'description',
+        name: 'description',
+        content: description,
+      },
+      {
+        hid: 'og:description',
+        property: 'og:description',
+        content: description,
+      },
+      {
+        hid: 'og:url',
+        property: 'og:url',
+        content: `${EXTERNAL_HOST}${this.$route.path}`,
+      },
+      {
+        hid: 'og:image',
+        property: 'og:image',
+        content: ogImage,
+      },
+      {
+        hid: 'likecoin:wallet',
+        name: 'likecoin:wallet',
+        content: this.iscnOwner,
+      },
+    ];
     const iscnOwnerPerson = {
       '@context': 'http://www.schema.org',
       '@type': 'Person',
@@ -573,7 +605,6 @@ export default {
           name: 'Writing NFT',
         },
         sku: this.classId,
-        iscn: this.iscnId,
         isbn: this.iscnData?.contentMetadata?.isbn,
         datePublished: this.iscnData?.recordTimestamp,
         url: `${EXTERNAL_HOST}${this.$route.path}`,
@@ -590,6 +621,13 @@ export default {
           }),
         },
         subjectOf: threeDModel,
+        additionalProperty: [
+          {
+            '@type': 'PropertyValue',
+            propertyID: 'iscn',
+            value: this.iscnId,
+          },
+        ],
       });
     }
     if (this.nftEditions) {
@@ -608,7 +646,6 @@ export default {
         },
         author: iscnOwnerPerson,
         sku: this.classId,
-        iscn: this.iscnId,
         isbn: this.iscnData?.contentMetadata?.isbn,
         inLanguage: this.iscnData?.contentMetadata?.inLanguage,
         productGroupID: this.classId,
@@ -617,6 +654,14 @@ export default {
         workExample: [],
         hasVariant: [],
         variesBy: ['https://schema.org/BookEdition'],
+
+        additionalProperty: [
+          {
+            '@type': 'PropertyValue',
+            propertyID: 'iscn',
+            value: this.iscnId,
+          },
+        ],
       };
       this.nftEditions.forEach(e => {
         schemas.push({
@@ -629,7 +674,6 @@ export default {
           image: [ogImage],
           sku: `${this.classId}-${e.index}`,
           inProductGroupWithID: this.classId,
-          iscn: this.iscnId,
           isbn: this.iscnData?.contentMetadata?.isbn,
           inLanguage: this.iscnData?.contentMetadata?.inLanguage,
           bookFormat: 'https://schema.org/EBook',
@@ -655,6 +699,13 @@ export default {
             }),
           },
           subjectOf: threeDModel,
+          additionalProperty: [
+            {
+              '@type': 'PropertyValue',
+              propertyID: 'iscn',
+              value: this.iscnId,
+            },
+          ],
         });
         bookSchema.workExample.push({
           '@id': `@${this.classId}-${e.index}`,
@@ -664,34 +715,77 @@ export default {
         });
       });
       schemas.push(bookSchema);
+      if (this.nftEdition?.price) {
+        const e = this.nftEdition;
+        [
+          {
+            hid: 'og:price:amount',
+            property: 'og:price:amount',
+            content: e.price,
+          },
+          {
+            hid: 'product:price:amount',
+            property: 'product:price:amount',
+            content: e.price,
+          },
+          {
+            hid: 'og:price:currency',
+            property: 'og:price:currency',
+            content: 'USD',
+          },
+          {
+            hid: 'product:price:currency',
+            property: 'product:price:currency',
+            content: 'USD',
+          },
+          {
+            hid: 'og:availability',
+            property: 'og:availability',
+            content: e.stock ? 'in stock' : 'out of stock',
+          },
+          {
+            hid: 'product:brand',
+            property: 'product:brand',
+            content: 'NFT Book',
+          },
+          {
+            hide: 'product:locale',
+            property: 'product:locale',
+            content: this.$i18n.locale,
+          },
+          {
+            hid: 'product:catalog_id',
+            property: 'product:catalog_id',
+            content: `${this.classId}-${e.index}`,
+          },
+          {
+            hid: 'product:retailer_item_id',
+            property: 'product:retailer_item_id',
+            content: `${this.classId}-${e.index}`,
+          },
+          {
+            hid: 'product:category',
+            property: 'product:category',
+            content: 543542,
+          },
+          {
+            hid: 'product:condition',
+            property: 'product:condition',
+            content: 'new',
+          },
+        ].forEach(m => meta.push(m));
+        meta.find(m => m.hid === 'og:url').content = `${EXTERNAL_HOST}${
+          this.$route.path
+        }?price_index=${e.index}`;
+        if (this.iscnData?.contentMetadata?.isbn) {
+          meta.push({
+            hid: 'product:isbn',
+            property: 'product:isbn',
+            content: this.iscnData?.contentMetadata?.isbn,
+          });
+        }
+      }
     }
-    const meta = [
-      {
-        hid: 'og:title',
-        property: 'og:title',
-        content: title,
-      },
-      {
-        hid: 'description',
-        name: 'description',
-        content: description,
-      },
-      {
-        hid: 'og:description',
-        property: 'og:description',
-        content: description,
-      },
-      {
-        hid: 'og:image',
-        property: 'og:image',
-        content: ogImage,
-      },
-      {
-        hid: 'likecoin:wallet',
-        name: 'likecoin:wallet',
-        content: this.iscnOwner,
-      },
-    ];
     if (this.isNFTHidden) {
       meta.push({
         hid: 'robots',

--- a/src/pages/nft/class/_classId/index.vue
+++ b/src/pages/nft/class/_classId/index.vue
@@ -777,6 +777,16 @@ export default {
         meta.find(m => m.hid === 'og:url').content = `${EXTERNAL_HOST}${
           this.$route.path
         }?price_index=${e.index}`;
+        if (e.name) {
+          let titleWithEdition =
+            this.NFTName || this.$t('nft_details_page_title');
+          if (e.name) titleWithEdition += ` - ${e.name}`;
+          if (this.iscnWorkAuthor) {
+            titleWithEdition += ` - ${this.iscnWorkAuthor}`;
+          }
+          titleWithEdition += ` - ${this.$t('nft_details_page_title_book')}`;
+          meta.find(m => m.hid === 'og:title').content = titleWithEdition;
+        }
         if (this.iscnData?.contentMetadata?.isbn) {
           meta.push({
             hid: 'product:isbn',

--- a/src/pages/nft/collection/_collectionId/index.vue
+++ b/src/pages/nft/collection/_collectionId/index.vue
@@ -294,6 +294,11 @@ export default {
           property: 'product:condition',
           content: 'new',
         },
+        {
+          hid: 'product:custom_label_0',
+          property: 'product:custom_label_0',
+          content: this.collectionOwner,
+        },
       ].forEach(m => meta.push(m));
     }
     return {

--- a/src/pages/nft/collection/_collectionId/index.vue
+++ b/src/pages/nft/collection/_collectionId/index.vue
@@ -154,6 +154,12 @@ export default {
         content: description,
       },
       {
+        hid: 'og:url',
+        property: 'og:url',
+        content: `${EXTERNAL_HOST}${this.$route.path}`,
+      },
+
+      {
         hid: 'og:image',
         property: 'og:image',
         content: ogImage,
@@ -232,8 +238,64 @@ export default {
           }),
         },
       });
+      [
+        {
+          hid: 'og:price:amount',
+          property: 'og:price:amount',
+          content: this.collectionPrice,
+        },
+        {
+          hid: 'product:price:amount',
+          property: 'product:price:amount',
+          content: this.collectionPrice,
+        },
+        {
+          hid: 'og:price:currency',
+          property: 'og:price:currency',
+          content: 'USD',
+        },
+        {
+          hid: 'product:price:currency',
+          property: 'product:price:currency',
+          content: 'USD',
+        },
+        {
+          hid: 'og:availability',
+          property: 'og:availability',
+          content: this.collection?.stock ? 'in stock' : 'out of stock',
+        },
+        {
+          hid: 'product:brand',
+          property: 'product:brand',
+          content: 'NFT Book',
+        },
+        {
+          hide: 'product:locale',
+          property: 'product:locale',
+          content: this.$i18n.locale,
+        },
+        {
+          hid: 'product:catalog_id',
+          property: 'product:catalog_id',
+          content: this.collectionId,
+        },
+        {
+          hid: 'product:retailer_item_id',
+          property: 'product:retailer_item_id',
+          content: this.collectionId,
+        },
+        {
+          hid: 'product:category',
+          property: 'product:category',
+          content: 543542,
+        },
+        {
+          hid: 'product:condition',
+          property: 'product:condition',
+          content: 'new',
+        },
+      ].forEach(m => meta.push(m));
     }
-    // ProductCollection
     return {
       title,
       meta,


### PR DESCRIPTION
Since facebook cannot parse json-ld with multiple `@type` like google does, and also likely does not support product variant in a same page, we set the current edition product info in og

https://developers.facebook.com/docs/marketing-api/catalog/reference/#og-tags